### PR TITLE
GET /records/{recordId}/comments の改善

### DIFF
--- a/development/backend/src/api.js
+++ b/development/backend/src/api.js
@@ -751,15 +751,22 @@ const getComments = async (req, res) => {
 
   const recordId = req.params.recordId;
 
-  const commentQs = `select * from record_comment where linked_record_id = ? order by created_at desc`;
+  const commentQs = `select record_comment.comment_id,\
+ record_comment.value,\
+ record_comment.created_by,\
+ record_comment.created_at,\
+ group_member.group_id,\
+ user.name\
+ from record_comment\
+ join group_member on group_member.user_id = record_comment.created_by\
+ join user on user.user_id = record_comment.created_by\
+ where linked_record_id = ? order by created_at desc;`
 
   const [commentResult] = await pool.query(commentQs, [`${recordId}`]);
   mylog(commentResult);
 
   const commentList = Array(commentResult.length);
 
-  const searchPrimaryGroupQs = `select * from group_member where user_id = ? and is_primary = true`;
-  const searchUserQs = `select * from user where user_id = ?`;
   const searchGroupQs = `select * from group_info where group_id = ?`;
   for (let i = 0; i < commentResult.length; i++) {
     let commentInfo = {
@@ -772,25 +779,18 @@ const getComments = async (req, res) => {
     };
     const line = commentResult[i];
 
-    const [primaryResult] = await pool.query(searchPrimaryGroupQs, [line.created_by]);
-    if (primaryResult.length === 1) {
-      const primaryGroupId = primaryResult[0].group_id;
+    commentInfo.commentId = line.comment_id;
+    commentInfo.value = line.value;
+    commentInfo.createdBy = line.created_by;
+    commentInfo.createdAt = line.created_at;
+    commentInfo.createdByName = line.name;
 
+    if (line.group_id) {
       const [groupResult] = await pool.query(searchGroupQs, [primaryGroupId]);
       if (groupResult.length === 1) {
         commentInfo.createdByPrimaryGroupName = groupResult[0].name;
       }
     }
-
-    const [userResult] = await pool.query(searchUserQs, [line.created_by]);
-    if (userResult.length === 1) {
-      commentInfo.createdByName = userResult[0].name;
-    }
-
-    commentInfo.commentId = line.comment_id;
-    commentInfo.value = line.value;
-    commentInfo.createdBy = line.created_by;
-    commentInfo.createdAt = line.created_at;
 
     commentList[i] = commentInfo;
   }

--- a/development/backend/src/api.js
+++ b/development/backend/src/api.js
@@ -758,7 +758,7 @@ const getComments = async (req, res) => {
  group_member.group_id,\
  user.name\
  from record_comment\
- join group_member on group_member.user_id = record_comment.created_by\
+ join group_member on group_member.user_id = record_comment.created_by and group_member.is_primary = true\
  join user on user.user_id = record_comment.created_by\
  where linked_record_id = ? order by created_at desc;`
 

--- a/development/backend/src/api.js
+++ b/development/backend/src/api.js
@@ -756,9 +756,11 @@ const getComments = async (req, res) => {
  record_comment.created_by,\
  record_comment.created_at,\
  group_member.group_id,\
- user.name\
+ user.name,\
+ group_info.name as group_name\
  from record_comment\
  join group_member on group_member.user_id = record_comment.created_by and group_member.is_primary = true\
+ join group_info on group_info.group_id = group_member.group_id\
  join user on user.user_id = record_comment.created_by\
  where linked_record_id = ? order by created_at desc;`
 
@@ -767,7 +769,6 @@ const getComments = async (req, res) => {
 
   const commentList = Array(commentResult.length);
 
-  const searchGroupQs = `select * from group_info where group_id = ?`;
   for (let i = 0; i < commentResult.length; i++) {
     let commentInfo = {
       commentId: '',
@@ -784,13 +785,7 @@ const getComments = async (req, res) => {
     commentInfo.createdBy = line.created_by;
     commentInfo.createdAt = line.created_at;
     commentInfo.createdByName = line.name;
-
-    if (line.group_id) {
-      const [groupResult] = await pool.query(searchGroupQs, [line.group_id]);
-      if (groupResult.length === 1) {
-        commentInfo.createdByPrimaryGroupName = groupResult[0].name;
-      }
-    }
+    commentInfo.createdByPrimaryGroupName = line.group_name;
 
     commentList[i] = commentInfo;
   }

--- a/development/backend/src/api.js
+++ b/development/backend/src/api.js
@@ -786,7 +786,7 @@ const getComments = async (req, res) => {
     commentInfo.createdByName = line.name;
 
     if (line.group_id) {
-      const [groupResult] = await pool.query(searchGroupQs, [primaryGroupId]);
+      const [groupResult] = await pool.query(searchGroupQs, [line.group_id]);
       if (groupResult.length === 1) {
         commentInfo.createdByPrimaryGroupName = groupResult[0].name;
       }


### PR DESCRIPTION
cat result-16161737.log
```
GET:/categories                                  success:11 subtotal: 8
POST:/files                                      success:5 subtotal: 8
GET:/record-views/allActive                      success:0 subtotal: 0
GET:/record-views/allClosed                      success:0 subtotal: 0
GET:/record-views/mineActive                     success:0 subtotal: 0
GET:/record-views/tomeActive                     success:0 subtotal: 0
POST:/records                                    success:5 subtotal: 6
GET:/records/[recordId]                          success:0 subtotal: 0
PUT:/records/[recordId]                          success:12 subtotal: 10
GET:/records/[recordId]/comments                 success:13 subtotal: 12
POST:/records/[recordId]/comments                success:8 subtotal: 8
GET:/records/[recordId]/files/[itemId]           success:10 subtotal: 10
GET:/records/[recordId]/files/[itemId]/thumbnail success:10 subtotal: 10


===============================================


スコアは 72 点


===============================================
```